### PR TITLE
fix: use absolute $HOME paths in home::symlink

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -36,7 +36,7 @@ p6df::modules::jira::langs() {
 ######################################################################
 p6df::modules::jira::home::symlink() {
 
-    p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-jira/share/.jira-cli.json" .jira-cli.json
+    p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-jira/share/.jira-cli.json" "$HOME/.jira-cli.json"
 
     p6_return_void
 }


### PR DESCRIPTION
Symlink targets were using relative paths (e.g. `.aws`) instead of absolute `$HOME/.aws`. Fixes symlinks when not run from $HOME.