### PR TITLE
chore: [OPS-15] move confluence and figma out of jira module

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Summary
 
-Install and configure Jira, Confluence, and Figma CLIs for shell and Codex usage.
+Install and configure Jira CLI for shell and Codex usage.
 
 ## Contributing
 
@@ -40,22 +40,16 @@ Install and configure Jira, Confluence, and Figma CLIs for shell and Codex usage
 - `p6df::modules::jira::home::symlink()`
 - `p6df::modules::jira::langs()`
 - `p6df::modules::jira::profile::off()`
-- `p6df::modules::jira::profile::on(profile, site, email, token, figma_token)`
+- `p6df::modules::jira::profile::on(profile, site, email, token)`
 
 ## ENV
 
-- Atlassian/Jira/Confluence:
+- Atlassian/Jira:
   - `ATLASSIAN_SITE`
   - `ATLASSIAN_EMAIL`
   - `ATLASSIAN_API_TOKEN`
   - `JIRA_HOST`
   - `JIRA_API_TOKEN`
-  - `CONFLUENCE_DOMAIN`
-  - `CONFLUENCE_EMAIL`
-  - `CONFLUENCE_API_TOKEN`
-- Figma:
-  - `FIGMA_API_TOKEN`
-  - `FIGMA_TOKEN`
 - Dotfiles profile:
   - `P6_DFZ_PROFILE_JIRA`
 

--- a/init.zsh
+++ b/init.zsh
@@ -21,13 +21,7 @@ p6df::modules::jira::deps() {
 ######################################################################
 p6df::modules::jira::langs() {
 
-    # Jira + Confluence community CLIs
     p6_js_npm_global_install "@pchuri/jira-cli"
-    p6_js_npm_global_install "confluence-cli"
-
-    # Figma CLI tools
-    p6_js_npm_global_install "@figma-export/cli"
-    p6_js_npm_global_install "figma-developer-mcp"
 
     p6_return_void
 }
@@ -57,8 +51,6 @@ p6df::modules::jira::home::symlink() {
 p6df::modules::jira::aliases::init() {
 
     p6_alias "jcli" "jira"
-    p6_alias "ccli" "confluence"
-    p6_alias "fcli" "figma-export"
 
     p6_return_void
 }
@@ -66,16 +58,15 @@ p6df::modules::jira::aliases::init() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::jira::profile::on(profile, site, email, token, figma_token)
+# Function: p6df::modules::jira::profile::on(profile, site, email, token)
 #
 #  Args:
 #	profile -
 #	site -
 #	email -
 #	token -
-#	figma_token -
 #
-#  Environment:	 ATLASSIAN_API_TOKEN ATLASSIAN_EMAIL ATLASSIAN_SITE CONFLUENCE_API_TOKEN CONFLUENCE_DOMAIN CONFLUENCE_EMAIL FIGMA_API_TOKEN FIGMA_TOKEN JIRA_API_TOKEN JIRA_HOST P6_DFZ_PROFILE_JIRA
+#  Environment:	 ATLASSIAN_API_TOKEN ATLASSIAN_EMAIL ATLASSIAN_SITE JIRA_API_TOKEN JIRA_HOST P6_DFZ_PROFILE_JIRA
 #>
 ######################################################################
 p6df::modules::jira::profile::on() {
@@ -83,7 +74,6 @@ p6df::modules::jira::profile::on() {
   local site="$2"
   local email="$3"
   local token="$4"
-  local figma_token="${5:-}"
 
   p6_env_export "P6_DFZ_PROFILE_JIRA" "$profile"
 
@@ -96,16 +86,6 @@ p6df::modules::jira::profile::on() {
   p6_env_export "JIRA_HOST" "$site"
   p6_env_export "JIRA_API_TOKEN" "$token"
 
-  # Confluence CLI common vars
-  p6_env_export "CONFLUENCE_DOMAIN" "$site"
-  p6_env_export "CONFLUENCE_EMAIL" "$email"
-  p6_env_export "CONFLUENCE_API_TOKEN" "$token"
-
-  if p6_string_blank_NOT "$figma_token"; then
-    p6_env_export "FIGMA_API_TOKEN" "$figma_token"
-    p6_env_export "FIGMA_TOKEN" "$figma_token"
-  fi
-
   p6_return_void
 }
 
@@ -114,7 +94,7 @@ p6df::modules::jira::profile::on() {
 #
 # Function: p6df::modules::jira::profile::off()
 #
-#  Environment:	 ATLASSIAN_API_TOKEN ATLASSIAN_EMAIL ATLASSIAN_SITE CONFLUENCE_API_TOKEN CONFLUENCE_DOMAIN CONFLUENCE_EMAIL FIGMA_API_TOKEN FIGMA_TOKEN JIRA_API_TOKEN JIRA_HOST P6_DFZ_PROFILE_JIRA
+#  Environment:	 ATLASSIAN_API_TOKEN ATLASSIAN_EMAIL ATLASSIAN_SITE JIRA_API_TOKEN JIRA_HOST P6_DFZ_PROFILE_JIRA
 #>
 ######################################################################
 p6df::modules::jira::profile::off() {
@@ -127,13 +107,6 @@ p6df::modules::jira::profile::off() {
 
   p6_env_export_un JIRA_HOST
   p6_env_export_un JIRA_API_TOKEN
-
-  p6_env_export_un CONFLUENCE_DOMAIN
-  p6_env_export_un CONFLUENCE_EMAIL
-  p6_env_export_un CONFLUENCE_API_TOKEN
-
-  p6_env_export_un FIGMA_API_TOKEN
-  p6_env_export_un FIGMA_TOKEN
 
   p6_return_void
 }


### PR DESCRIPTION
## Summary
- remove Confluence and Figma CLI setup from p6df-jira
- keep Jira install, alias, and profile variables only
- update README/ENV docs to Jira-only scope

## Validation
- `bash -n init.zsh`
- `markdownlint README.md`
