### PR TITLE
fix(jira): correct prompt prefix when only token vars are set

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Install and configure Jira CLI for shell and Codex usage.
 - `p6df::modules::jira::langs()`
 - `p6df::modules::jira::profile::off()`
 - `p6df::modules::jira::profile::on(profile, site, email, token)`
+- `str str = p6df::modules::jira::prompt::mod()`
 
 ## ENV
 

--- a/init.zsh
+++ b/init.zsh
@@ -58,6 +58,43 @@ p6df::modules::jira::aliases::init() {
 ######################################################################
 #<
 #
+# Function: str str = p6df::modules::jira::prompt::mod()
+#
+#  Returns:
+#	str - str
+#
+#  Environment:	 ATLASSIAN_API_TOKEN ATLASSIAN_SITE JIRA_API_TOKEN JIRA_HOST P6_DFZ_PROFILE_JIRA
+#>
+######################################################################
+p6df::modules::jira::prompt::mod() {
+  local str
+
+  if p6_string_blank_NOT "$P6_DFZ_PROFILE_JIRA"; then
+    if p6_string_blank_NOT "$ATLASSIAN_SITE"; then
+      str="jira:\t\t  $P6_DFZ_PROFILE_JIRA:"
+      str=$(p6_string_append "$str" "$ATLASSIAN_SITE" " ")
+    elif p6_string_blank_NOT "$JIRA_HOST"; then
+      str="jira:\t\t  $P6_DFZ_PROFILE_JIRA:"
+      str=$(p6_string_append "$str" "$JIRA_HOST" " ")
+    fi
+
+    if p6_string_blank_NOT "$ATLASSIAN_EMAIL"; then
+      str=$(p6_string_append "$str" "$ATLASSIAN_EMAIL" "/")
+    fi
+    if p6_string_blank_NOT "$ATLASSIAN_API_TOKEN"; then
+      str=$(p6_string_append "$str" "api" "/")
+    fi
+    if p6_string_blank_NOT "$JIRA_API_TOKEN"; then
+      str=$(p6_string_append "$str" "japi" "/")
+    fi
+  fi
+
+  p6_return_str "$str"
+}
+
+######################################################################
+#<
+#
 # Function: p6df::modules::jira::profile::on(profile, site, email, token)
 #
 #  Args:

--- a/init.zsh
+++ b/init.zsh
@@ -67,24 +67,30 @@ p6df::modules::jira::aliases::init() {
 #>
 ######################################################################
 p6df::modules::jira::prompt::mod() {
-  local str
+  local str=""
+  local profile="${P6_DFZ_PROFILE_JIRA:-}"
+  local site="${ATLASSIAN_SITE:-}"
+  local host="${JIRA_HOST:-}"
+  local email="${ATLASSIAN_EMAIL:-}"
+  local atlassian_api="${ATLASSIAN_API_TOKEN:-}"
+  local jira_api="${JIRA_API_TOKEN:-}"
 
-  if p6_string_blank_NOT "$P6_DFZ_PROFILE_JIRA"; then
-    if p6_string_blank_NOT "$ATLASSIAN_SITE"; then
-      str="jira:\t\t  $P6_DFZ_PROFILE_JIRA:"
-      str=$(p6_string_append "$str" "$ATLASSIAN_SITE" " ")
-    elif p6_string_blank_NOT "$JIRA_HOST"; then
-      str="jira:\t\t  $P6_DFZ_PROFILE_JIRA:"
-      str=$(p6_string_append "$str" "$JIRA_HOST" " ")
+  if p6_string_blank_NOT "$profile"; then
+    str="jira:\t\t  ${profile}:"
+
+    if p6_string_blank_NOT "$site"; then
+      str=$(p6_string_append "$str" "$site" " ")
+    elif p6_string_blank_NOT "$host"; then
+      str=$(p6_string_append "$str" "$host" " ")
     fi
 
-    if p6_string_blank_NOT "$ATLASSIAN_EMAIL"; then
-      str=$(p6_string_append "$str" "$ATLASSIAN_EMAIL" "/")
+    if p6_string_blank_NOT "$email"; then
+      str=$(p6_string_append "$str" "$email" "/")
     fi
-    if p6_string_blank_NOT "$ATLASSIAN_API_TOKEN"; then
+    if p6_string_blank_NOT "$atlassian_api"; then
       str=$(p6_string_append "$str" "api" "/")
     fi
-    if p6_string_blank_NOT "$JIRA_API_TOKEN"; then
+    if p6_string_blank_NOT "$jira_api"; then
       str=$(p6_string_append "$str" "japi" "/")
     fi
   fi


### PR DESCRIPTION
## Summary
- fix Jira prompt rendering when profile is set but site/host is empty
- always initialize prompt with `jira: <profile>:` before appending auth fragments
- normalize env reads with safe defaults

## Validation
- `bash -n init.zsh`
- verified output with `P6_DFZ_PROFILE_JIRA=Arkestro` and only token vars set: `jira: Arkestro:/api/japi`
