### PR TITLE
feat: add mcp() hook to install Atlassian MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [Contributing](#contributing)
 - [Code of Conduct](#code-of-conduct)
 - [Usage](#usage)
+  - [Aliases](#aliases)
   - [Functions](#functions)
 - [Hierarchy](#hierarchy)
 - [Author](#author)
@@ -17,7 +18,8 @@
 
 ## Summary
 
-Install and configure Jira CLI for shell and Codex usage.
+Install and configure Jira CLI for shell usage, with profile switching and
+MCP server (`@modelcontextprotocol/server-atlassian`) for AI-driven issue management.
 
 ## Contributing
 
@@ -29,6 +31,10 @@ Install and configure Jira CLI for shell and Codex usage.
 
 ## Usage
 
+### Aliases
+
+- `jcli` -> `jira`
+
 ### Functions
 
 #### p6df-jira
@@ -39,29 +45,25 @@ Install and configure Jira CLI for shell and Codex usage.
 - `p6df::modules::jira::deps()`
 - `p6df::modules::jira::home::symlink()`
 - `p6df::modules::jira::langs()`
+- `p6df::modules::jira::mcp()`
 - `p6df::modules::jira::profile::off()`
 - `p6df::modules::jira::profile::on(profile, site, email, token)`
+  - Args:
+    - profile
+    - site
+    - email
+    - token
 - `str str = p6df::modules::jira::prompt::mod()`
-
-## ENV
-
-- Atlassian/Jira:
-  - `ATLASSIAN_SITE`
-  - `ATLASSIAN_EMAIL`
-  - `ATLASSIAN_API_TOKEN`
-  - `JIRA_HOST`
-  - `JIRA_API_TOKEN`
-- Dotfiles profile:
-  - `P6_DFZ_PROFILE_JIRA`
 
 ## Hierarchy
 
 ```text
 .
 ├── init.zsh
-└── README.md
+├── README.md
+└── share
 
-1 directory, 2 files
+2 directories, 2 files
 ```
 
 ## Author

--- a/init.zsh
+++ b/init.zsh
@@ -31,7 +31,7 @@ p6df::modules::jira::langs() {
 #
 # Function: p6df::modules::jira::home::symlink()
 #
-#  Environment:	 P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
 ######################################################################
 p6df::modules::jira::home::symlink() {
@@ -63,7 +63,7 @@ p6df::modules::jira::aliases::init() {
 #  Returns:
 #	str - str
 #
-#  Environment:	 ATLASSIAN_API_TOKEN ATLASSIAN_SITE JIRA_API_TOKEN JIRA_HOST P6_DFZ_PROFILE_JIRA
+#  Environment:	 ATLASSIAN_API_TOKEN ATLASSIAN_EMAIL ATLASSIAN_SITE JIRA_API_TOKEN JIRA_HOST P6_DFZ_PROFILE_JIRA
 #>
 ######################################################################
 p6df::modules::jira::prompt::mod() {
@@ -150,6 +150,20 @@ p6df::modules::jira::profile::off() {
 
   p6_env_export_un JIRA_HOST
   p6_env_export_un JIRA_API_TOKEN
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::jira::mcp()
+#
+#>
+######################################################################
+p6df::modules::jira::mcp() {
+
+  p6_js_npm_global_install "@modelcontextprotocol/server-atlassian"
 
   p6_return_void
 }


### PR DESCRIPTION
## Summary

- `mcp()`: installs `@modelcontextprotocol/server-atlassian` for AI-driven Jira access
- No `mcp::env()` needed: `profile::on` directly sets `ATLASSIAN_API_TOKEN`,
  `ATLASSIAN_SITE`, `ATLASSIAN_EMAIL`, `JIRA_HOST`, and `JIRA_API_TOKEN`

## Test plan

- [ ] `p6df mcp p6df-jira` installs `@modelcontextprotocol/server-atlassian`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)