### PR TITLE
fix: use correct @rokealvo/jira-mcp package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@
 
 ## Summary
 
-Install and configure Jira CLI for shell usage, with profile switching and
-MCP server (`@modelcontextprotocol/server-atlassian`) for AI-driven issue management.
+p6df module for Jira: CLI tools (`@pchuri/jira-cli`), profile switching
+(`JIRA_API_TOKEN`, `JIRA_USER_EMAIL`, `JIRA_URL`), and MCP server
+(`@rokealvo/jira-mcp`) for AI-driven issue management.
 
 ## Contributing
 

--- a/init.zsh
+++ b/init.zsh
@@ -163,7 +163,7 @@ p6df::modules::jira::profile::off() {
 ######################################################################
 p6df::modules::jira::mcp() {
 
-  p6_js_npm_global_install "@modelcontextprotocol/server-atlassian"
+  p6_js_npm_global_install "@rokealvo/jira-mcp"
 
   p6_return_void
 }


### PR DESCRIPTION
## Summary

- Fix `mcp()` hook: replace `@modelcontextprotocol/server-atlassian` (incorrect) with `@rokealvo/jira-mcp` (the actual npm package for the Jira MCP server)

## Test plan

- [ ] `p6df mcp` installs `@rokealvo/jira-mcp` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)