### PR TITLE
fix: install mcp-atlassian via brew instead of npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 p6df module for Jira: CLI tools (`@pchuri/jira-cli`), profile switching
 (`JIRA_API_TOKEN`, `JIRA_USER_EMAIL`, `JIRA_URL`), and MCP server
-(`@rokealvo/jira-mcp`) for AI-driven issue management.
+(`mcp-atlassian` via brew) for AI-driven issue management.
 
 ## Contributing
 

--- a/init.zsh
+++ b/init.zsh
@@ -163,7 +163,7 @@ p6df::modules::jira::profile::off() {
 ######################################################################
 p6df::modules::jira::mcp() {
 
-  p6_js_npm_global_install "@rokealvo/jira-mcp"
+  p6df::core::homebrew::cli::brew::install mcp-atlassian
 
   p6_return_void
 }


### PR DESCRIPTION
## Summary

- Replace `p6_js_npm_global_install "@rokealvo/jira-mcp"` with `p6df::core::homebrew::cli::brew::install mcp-atlassian` — a bottled Homebrew formula covering both Jira and Confluence

## Test plan

- [ ] `p6df mcp` installs `mcp-atlassian` via brew

🤖 Generated with [Claude Code](https://claude.com/claude-code)