### PR TITLE
chore(jira): merge home::symlink into home::symlinks

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -31,27 +31,14 @@ p6df::modules::jira::langs() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::jira::home::symlink()
-#
-#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-p6df::modules::jira::home::symlink() {
-
-    p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-jira/share/.jira-cli.json" "$HOME/.jira-cli.json"
-
-    p6_return_void
-}
-
-######################################################################
-#<
-#
 # Function: p6df::modules::jira::home::symlinks()
 #
-#  Environment:	 HOME P6_DFZ_SRC_DIR
+#  Environment:	 HOME P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
 ######################################################################
 p6df::modules::jira::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-jira/share/.jira-cli.json" "$HOME/.jira-cli.json"
 
   p6_file_symlink "$P6_DFZ_SRC_DIR/netresearch/jira-skill/skills/jira-communication" "$HOME/.claude/skills/jira-communication"
   p6_file_symlink "$P6_DFZ_SRC_DIR/netresearch/jira-skill/skills/jira-syntax"        "$HOME/.claude/skills/jira-syntax"


### PR DESCRIPTION
## What
Merge ~/.jira-cli.json dotfile symlink from never-called singular function into auto-called plural. Delete singular.

## Why
p6df-core dispatches home::symlinks (plural) only. ~/.jira-cli.json was only symlinked from prior manual creation.

## Test plan
- `p6df home symlinks` recreates ~/.jira-cli.json

## Dependencies
None