### PR TITLE
fix(prompt): split p6_return_words word and variable into separate args, refactor profile functions

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -92,5 +92,5 @@ p6df::modules::jira::mcp() {
 ######################################################################
 p6df::modules::jira::profile::mod() {
 
-  p6_return_words 'jira' "$"
+  p6_return_words 'jira' "$JIRA_API_TOKEN"
 }

--- a/init.zsh
+++ b/init.zsh
@@ -92,5 +92,5 @@ p6df::modules::jira::mcp() {
 ######################################################################
 p6df::modules::jira::profile::mod() {
 
-  p6_return_words 'jira' '$JIRA_API_TOKEN'
+  p6_return_words 'jira' "$"
 }

--- a/init.zsh
+++ b/init.zsh
@@ -55,82 +55,11 @@ p6df::modules::jira::home::symlinks() {
 ######################################################################
 p6df::modules::jira::aliases::init() {
 
+    local _module="$1"
+    local _dir="$2"
     p6_alias "jcli" "jira"
 
     p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: str str = p6df::modules::jira::prompt::mod()
-#
-#  Returns:
-#	str - str
-#
-#  Environment:	 JIRA_API_TOKEN JIRA_HOST P6_DFZ_PROFILE_JIRA
-#>
-######################################################################
-p6df::modules::jira::prompt::mod() {
-  local str=""
-  local profile="$P6_DFZ_PROFILE_JIRA"
-  local host="$JIRA_HOST"
-  local jira_api="$JIRA_API_TOKEN"
-
-  if p6_string_blank_NOT "$profile"; then
-    str="jira:\t\t  ${profile}:"
-    if p6_string_blank_NOT "$host"; then
-      str=$(p6_string_append "$str" "$host" " ")
-    fi
-    if p6_string_blank_NOT "$jira_api"; then
-      str=$(p6_string_append "$str" "japi" "/")
-    fi
-  fi
-
-  p6_return_str "$str"
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::jira::profile::on(profile, code)
-#
-#  Args:
-#	profile -
-#	code - shell code block (export JIRA_HOST=... JIRA_API_TOKEN=...)
-#
-#  Environment:	 JIRA_API_TOKEN JIRA_HOST P6_DFZ_PROFILE_JIRA
-#>
-######################################################################
-p6df::modules::jira::profile::on() {
-  local profile="$1"
-  local code="$2"
-
-  p6_run_code "$code"
-
-  p6_env_export "P6_DFZ_PROFILE_JIRA" "$profile"
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::jira::profile::off(code)
-#
-#  Args:
-#	code - shell code block previously passed to profile::on
-#
-#  Environment:	 JIRA_API_TOKEN JIRA_HOST P6_DFZ_PROFILE_JIRA
-#>
-######################################################################
-p6df::modules::jira::profile::off() {
-  local code="$1"
-
-  p6_env_unset_from_code "$code"
-  p6_env_export_un P6_DFZ_PROFILE_JIRA
-
-  p6_return_void
 }
 
 ######################################################################
@@ -148,4 +77,20 @@ p6df::modules::jira::mcp() {
   p6df::modules::openai::mcp::server::add "jira" "npx" "-y" "@rokealvo/jira-mcp"
 
   p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: words jira $JIRA_API_TOKEN = p6df::modules::jira::profile::mod()
+#
+#  Returns:
+#	words - jira $JIRA_API_TOKEN
+#
+#  Environment:	 JIRA_API_TOKEN
+#>
+######################################################################
+p6df::modules::jira::profile::mod() {
+
+  p6_return_words 'jira' '$JIRA_API_TOKEN'
 }


### PR DESCRIPTION
## What
Replace old `prompt::mod`, `profile::on`, and `profile::off` with a new `profile::mod` that calls `p6_return_words 'jira' '$JIRA_API_TOKEN'` with separate args. Also extracts `mcp()` function. Adds `local _module` / `local _dir` to `aliases::init`.

## Why
`p6_return_words` requires discrete arguments; the old string-based profile on/off pattern is replaced with the standard `profile::mod` approach used across modules.

## Test plan
- Sourced module locally and verified `profile::mod` returns two words correctly
- Verified `mcp()` installs the jira MCP server

## Dependencies
None