### PR TITLE
fix(jira): use single-quoted variables in profile::mod (deferred eval)

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -92,5 +92,5 @@ p6df::modules::jira::mcp() {
 ######################################################################
 p6df::modules::jira::profile::mod() {
 
-  p6_return_words 'jira' "$JIRA_API_TOKEN"
+  p6_return_words 'jira' '$JIRA_API_TOKEN'
 }


### PR DESCRIPTION
**What:** Restore single-quoted variables in profile::mod p6_return_words calls

**Why:** Variables are intentionally single-quoted; eval happens later via p6_return_words machinery. The SC2016 fix incorrectly expanded them at call time.

**Test plan:** Build CI passes

**Dependencies:** None