### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::jira::deps()
-#
-#>
-######################################################################
 p6df::modules::jira::deps() {
     ModuleDeps=(
         p6m7g8-dotfiles/p6df-atlassian
@@ -15,26 +9,15 @@ p6df::modules::jira::deps() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::jira::langs()
-#
-#>
-######################################################################
-p6df::modules::jira::langs() {
+p6df::modules::jira::aliases::init() {
 
-    p6_js_npm_global_install "@pchuri/jira-cli"
+    local _module="$1"
+    local _dir="$2"
+    p6_alias "jcli" "jira"
 
     p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::jira::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
 ######################################################################
 p6df::modules::jira::home::symlinks() {
 
@@ -47,27 +30,13 @@ p6df::modules::jira::home::symlinks() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::jira::aliases::init()
-#
-#>
-######################################################################
-p6df::modules::jira::aliases::init() {
+p6df::modules::jira::langs() {
 
-    local _module="$1"
-    local _dir="$2"
-    p6_alias "jcli" "jira"
+    p6_js_npm_global_install "@pchuri/jira-cli"
 
     p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::jira::mcp()
-#
-#>
 ######################################################################
 p6df::modules::jira::mcp() {
 
@@ -80,6 +49,42 @@ p6df::modules::jira::mcp() {
 }
 
 ######################################################################
+p6df::modules::jira::profile::mod() {
+
+  p6_return_words 'jira' '$JIRA_API_TOKEN'
+}
+######################################################################
+#<
+#
+# Function: p6df::modules::jira::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::jira::langs()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::jira::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::jira::aliases::init()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::jira::mcp()
+#
+#>
+######################################################################
 #<
 #
 # Function: words jira $JIRA_API_TOKEN = p6df::modules::jira::profile::mod()
@@ -89,8 +94,3 @@ p6df::modules::jira::mcp() {
 #
 #  Environment:	 JIRA_API_TOKEN
 #>
-######################################################################
-p6df::modules::jira::profile::mod() {
-
-  p6_return_words 'jira' '$JIRA_API_TOKEN'
-}

--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::jira::deps()
+#
+#>
+######################################################################
 p6df::modules::jira::deps() {
     ModuleDeps=(
         p6m7g8-dotfiles/p6df-atlassian
@@ -8,6 +14,12 @@ p6df::modules::jira::deps() {
     )
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::jira::aliases::init()
+#
+#>
 ######################################################################
 p6df::modules::jira::aliases::init() {
 
@@ -18,6 +30,13 @@ p6df::modules::jira::aliases::init() {
     p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::jira::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
 ######################################################################
 p6df::modules::jira::home::symlinks() {
 
@@ -30,6 +49,12 @@ p6df::modules::jira::home::symlinks() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::jira::langs()
+#
+#>
+######################################################################
 p6df::modules::jira::langs() {
 
     p6_js_npm_global_install "@pchuri/jira-cli"
@@ -37,6 +62,12 @@ p6df::modules::jira::langs() {
     p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::jira::mcp()
+#
+#>
 ######################################################################
 p6df::modules::jira::mcp() {
 
@@ -49,42 +80,6 @@ p6df::modules::jira::mcp() {
 }
 
 ######################################################################
-p6df::modules::jira::profile::mod() {
-
-  p6_return_words 'jira' '$JIRA_API_TOKEN'
-}
-######################################################################
-#<
-#
-# Function: p6df::modules::jira::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::jira::langs()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::jira::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::jira::aliases::init()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::jira::mcp()
-#
-#>
-######################################################################
 #<
 #
 # Function: words jira $JIRA_API_TOKEN = p6df::modules::jira::profile::mod()
@@ -94,3 +89,8 @@ p6df::modules::jira::profile::mod() {
 #
 #  Environment:	 JIRA_API_TOKEN
 #>
+######################################################################
+p6df::modules::jira::profile::mod() {
+
+  p6_return_words 'jira' '$JIRA_API_TOKEN'
+}


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None